### PR TITLE
Fix JSON logging in speedtest scripts

### DIFF
--- a/etc/rc.d/speedtest_run.sh
+++ b/etc/rc.d/speedtest_run.sh
@@ -9,4 +9,6 @@ if ! command -v speedtest >/dev/null 2>&1; then
 fi
 [ ! -f "$OUTFILE" ] && echo "[]" > "$OUTFILE"
 RESULT=$(speedtest --accept-license --accept-gdpr -f json)
-[ $? -eq 0 ] && echo "$RESULT" | jq -s 'input + .' "$OUTFILE" > "$OUTFILE.tmp" && mv "$OUTFILE.tmp" "$OUTFILE"
+if [ $? -eq 0 ]; then
+  echo "$RESULT" | jq -s '.[0] + [.[1]]' "$OUTFILE" - > "$OUTFILE.tmp" && mv "$OUTFILE.tmp" "$OUTFILE"
+fi

--- a/files/speedtest_run.sh
+++ b/files/speedtest_run.sh
@@ -19,5 +19,5 @@ fi
 # Run speedtest and append to JSON log
 RESULT=$(speedtest --accept-license --accept-gdpr -f json)
 if [ $? -eq 0 ]; then
-  echo "$RESULT" | jq -s 'input + .' "$OUTFILE" > "$OUTFILE.tmp" && mv "$OUTFILE.tmp" "$OUTFILE"
+  echo "$RESULT" | jq -s '.[0] + [.[1]]' "$OUTFILE" - > "$OUTFILE.tmp" && mv "$OUTFILE.tmp" "$OUTFILE"
 fi


### PR DESCRIPTION
## Summary
- correct jq expression when appending new results
- apply change to both service and files scripts

## Testing
- `sh -n etc/rc.d/speedtest_run.sh`
- `sh -n files/speedtest_run.sh`


------
https://chatgpt.com/codex/tasks/task_e_6840bd30aeb8832b9129f0b81d0bf4e9